### PR TITLE
by default allow all users to submit jobs

### DIFF
--- a/gridengine/host.conf.tmpl
+++ b/gridengine/host.conf.tmpl
@@ -1,7 +1,7 @@
 hostname	localhost
 load_scaling	NONE
 complex_values	NONE
-user_lists	arusers
+user_lists	NONE
 xuser_lists	NONE
 projects	NONE
 xprojects	NONE

--- a/gridengine/queue.conf.tmpl
+++ b/gridengine/queue.conf.tmpl
@@ -24,7 +24,7 @@ resume_method	NONE
 terminate_method	NONE
 notify	00:00:60
 owner_list	NONE
-user_lists	arusers
+user_lists	NONE
 xuser_lists	NONE
 subordinate_list	NONE
 complex_values	NONE


### PR DESCRIPTION
The arusers thing limits random users to run jobs. This makes using the container for testing difficult.